### PR TITLE
Tests: Bump EventStoreQuery to v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ How it works:
 * Filter events and only process ones for the specified Aggregate.
 * Get the Max Aggregate-Version from Database.
 * Send request to [EventStoreQuery][0] with the Max Aggregate-Version.
-* Get events from EventStoreQuery, and read the `Event.Action`.
+* Get events from EventStoreQuery.
 * Fan-Out events to their respective channels based on `Event.Action`.
 * Send service-response to specified Kafka-topic.
 

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
       - ./.envp
 
   go-eventstore-query:
-    image: terrextech/go-eventstore-query:v2.0.0
+    image: terrextech/go-eventstore-query:v2.1.0
     env_file:
       - ./.envq
 


### PR DESCRIPTION
Also replaces go-routines with 'select' in example, to ensure ordered-processing of events.