### PR TITLE
Add missing nil checks

### DIFF
--- a/poll/esresp_consumer.go
+++ b/poll/esresp_consumer.go
@@ -100,6 +100,9 @@ func (e *esRespHandler) ConsumeClaim(
 
 			// Distribute events to their respective channels
 			for _, event := range *events {
+				if event.TimeUUID == (uuuid.UUID{}) {
+					continue
+				}
 				eventResp := &EventResponse{
 					Event: event,
 					Error: krError,

--- a/poll/poll_suite_test.go
+++ b/poll/poll_suite_test.go
@@ -83,6 +83,9 @@ func (m *msgHandler) ConsumeClaim(
 		return errors.New("msgCallback cannot be nil")
 	}
 	for msg := range claim.Messages() {
+		if msg == nil {
+			continue
+		}
 		session.MarkMessage(msg, "")
 
 		val := m.msgCallback(msg)


### PR DESCRIPTION
Nil values are received on channels when closing them, causing nil-pointer errors. This fixes that.